### PR TITLE
Adding compat with Gridap0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Gridap = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
+Gridap = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Test works with Gridap 0.14. Compatibility with Gridap 0.14 is thus added. 