### PR TITLE
Remove redefinition of `mat` in numerical_setup

### DIFF
--- a/src/LinearSolver.jl
+++ b/src/LinearSolver.jl
@@ -201,7 +201,6 @@ function numerical_setup!(pns::PardisoNumericalSetup{T,Ti},mat::AbstractSparseMa
   iparm = pns.pss.iparm
   msglvl = pns.pss.msglvl
   pt = pns.pss.pt
-  mat = pns.pss.mat
   m,n = size(mat)
   phase = PHASE_NUMERICAL_FACTORIZATION
   f! = get_pardiso(Ti)


### PR DESCRIPTION
From #38 

From line 204

https://github.com/gridap/GridapPardiso.jl/blob/5d893b1352295228a07eba4d89e734f6e65212cf/src/LinearSolver.jl#L199-L204

This redefinition of `mat` causes the arguments `mat` to be ignored, thus the symbolic factorization is not actually reused when calling the numerical factorization on different matrices. 